### PR TITLE
メッセージフレームワーク( #73 ) を翻訳しました

### DIFF
--- a/ref/contrib/messages.txt
+++ b/ref/contrib/messages.txt
@@ -256,8 +256,7 @@ recorded level) を変更するために使われます(また、 `リクエス�
 
 メッセージレベルのデフォルトタグ(組み込みとカスタムタグのどちらでも)を変更するに
 は、 :setting:`MESSAGE_TAGS` へ変更したいレベルを含めた辞書を設定します。
-As this extends the default tags,
-上書きしたいレベルへあなたのタグを設定する必要があります::
+その場合は、上書きしたいレベルだけを指定してタグを設定します。::
 
     from django.contrib.messages import constants as messages
     MESSAGE_TAGS = {
@@ -331,8 +330,8 @@ As this extends the default tags,
    for the next request.
 
 たとえ、メッセージが一つであったとしても、それでも ``messages`` をイテレートし
-なければなりません、なぜなら、そうしなければ、そのメッセージのデータが次のリク
-エストで削除されないからです。
+なければなりません、なぜなら、そうしなければ、そのメッセージのストレージが次の
+リクエストまでに削除されないからです。
 
 .. Creating custom message levels
    ------------------------------
@@ -344,7 +343,7 @@ As this extends the default tags,
    level constants and use them to create more customized user feedback, e.g.::
 
 メッセージレベルは単なる整数に過ぎません、だから、あなたは独自のレベルの定数を
-定義して、 use them to create more customized user feedback, 例えば::
+定義して、よりカスタムされたユーザのフィードバックを生成できます。例えば::
 
     CRITICAL = 50
 


### PR DESCRIPTION
はじめまして、kjirou と申します。

メッセージフレームワークのページを翻訳いたしました。 
初回ということもあり、確認をお願いいたします。

以下、補足です。
- #73 のチケットに指示のあったSVNリポジトリが無くなっていたため、GitHubリポジトリから該当部分と思われるリビジョンを探して diff を取りました。この点の詳細は #73 のコメントを参照願います。
- 全体で 2 行、どうしても訳がわからなかった部分があり、そのまま残してある部分があります。申し訳ありませんが、助力いただいてもよろしいでしょうか。

よろしくお願いします！
