### PR TITLE
docutils 0.11 以降だとエラーになるのを修正

### DIFF
--- a/_ext/djangodocs.py
+++ b/_ext/djangodocs.py
@@ -109,6 +109,10 @@ class DjangoHTMLTranslator(SmartyPantsHTMLTranslator):
         self._table_row_index = 0 # Needed by Sphinx
         self.body.append(self.starttag(node, 'table', CLASS='docutils'))
 
+    # avoid error with docutils 0.11 or later
+    def depart_table(self, node):
+        self.body.append('</table>\n')
+
     # <big>? Really?
     def visit_desc_parameterlist(self, node):
         self.body.append('(')


### PR DESCRIPTION
docutils 0.11 をインストールしているとドキュメントビルド時にエラーで落ちます。

これは docutils 0.11 で HTMLTranslator の visit/depart_table の実装が変更されて、 djangodocs.py 内では visit_table のみをオーバーライドしているためです。

docutils 0.10 相当の depart_table を追加して、 docutils 0.11 以降でも落ちないようにしました。
